### PR TITLE
Bugfix/8.0/medical patient age on leap day

### DIFF
--- a/medical/models/medical_patient.py
+++ b/medical/models/medical_patient.py
@@ -20,7 +20,6 @@
 #
 # #############################################################################
 from openerp import models, fields, api
-from datetime import datetime
 from openerp.tools.translate import _
 from dateutil.relativedelta import relativedelta
 
@@ -35,11 +34,10 @@ class MedicalPatient(models.Model):
 
     @api.one
     def _compute_age(self):
-        """
-        age computed depending of the birth date of the
-        membership request
-        """
-        now = datetime.now()
+        """ Age computed depending on the birth date of the patient """
+        now = fields.Datetime.from_string(
+            self.env.context.get('date', fields.Datetime.now())
+        )
         if self.dob:
             dob = fields.Datetime.from_string(self.dob)
 

--- a/medical/views/medical_appointment_view.xml
+++ b/medical/views/medical_appointment_view.xml
@@ -84,7 +84,7 @@
             <field name="model">medical.appointment</field>
             <field eval="2" name="priority"/>
             <field name="arch" type="xml">
-                <calendar color="physician_id" date_start="appointment_date" date_stop="date_end" string="Calendar View" mode="week" >
+                <calendar color="physician_id" date_start="appointment_date" date_delay="duration" string="Calendar View" mode="week" >
                     <field name="patient_id"/>
                     <field name="physician_id"/>
                     <field name="duration"/>

--- a/medical/views/medical_menu.xml
+++ b/medical/views/medical_menu.xml
@@ -20,7 +20,7 @@
         <!--Appointment-->
 
         <menuitem id="medical_appointment_root"
-                  name="Appoitment"
+                  name="Appointment"
                   parent="medical_root"
                   sequence="20" />
 


### PR DESCRIPTION
This PR Odoo-izes the medical_patient datetime handling in age computation, as well as allows for injection of a static time for testability.

Tests upgraded to match, fixing #105 & also verifying that leap day is in-fact compatible with the calculations
