### PR TITLE
[8.0] [BUG] Medical Patient leap day compatibility and tests

### DIFF
--- a/medical/models/medical_patient.py
+++ b/medical/models/medical_patient.py
@@ -20,7 +20,6 @@
 #
 # #############################################################################
 from openerp import models, fields, api
-from datetime import datetime
 from openerp.tools.translate import _
 from dateutil.relativedelta import relativedelta
 
@@ -35,11 +34,10 @@ class MedicalPatient(models.Model):
 
     @api.one
     def _compute_age(self):
-        """
-        age computed depending of the birth date of the
-        membership request
-        """
-        now = datetime.now()
+        """ Age computed depending on the birth date of the patient """
+        now = fields.Datetime.from_string(
+            self.env.context.get('date', fields.Datetime.now())
+        )
         if self.dob:
             dob = fields.Datetime.from_string(self.dob)
 


### PR DESCRIPTION
This PR Odoo-izes the medical_patient datetime handling in age computation, as well as allows for injection of a static time for testability.

Tests upgraded to match, fixing #105 & also verifying that leap day is in-fact compatible with the calculations.
