### PR TITLE
[ADD][9.0] medical_base_kanban: Module for abstract stages

### DIFF
--- a/medical_base_kanban/README.rst
+++ b/medical_base_kanban/README.rst
@@ -1,0 +1,78 @@
+.. image:: https://img.shields.io/badge/license-AGPL--3-blue.svg
+    :alt: License: AGPL-3
+
+======================
+Medical Base -  Kanban
+======================
+
+This module provides abstract KanBan logic for use in Medical Resources.
+
+
+Usage
+=====
+
+The ``medical.base.kanban`` model should be inherited in order to add KanBan
+and Stage functionality to any record
+
+.. code-block:: python
+
+    class MyModel(models.Model):
+        _name = 'my.model'
+        _inherit = 'medical.base.kanban'
+        
+A Base KanBan view is also provided, which can be integrated into child views
+
+.. code-block:: xml
+
+    <record id="my_model_kanban_view" model="ir.ui.view">
+        <field name="name">My Record</field>
+        <field name="model">my.model</field>
+        <field name="inherit_id" ref="medical_base_state.medical_base_kanban_view" />
+        <field name="arch" type="xml">
+            <!-- Add your contextual changes here w/ XPath -->
+        </field>
+    </record>
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/159/9.0
+
+For further information, please visit:
+
+* https://www.odoo.com/forum/help-1
+
+Known issues / Roadmap
+======================
+
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues <https://github.com/OCA/vertical-medical/issues>`_.
+In case of trouble, please check there if your issue has already been reported.
+If you spotted it first, help us smashing it by providing a detailed and welcomed feedback
+`here <https://github.com/OCA/vertical-medical/issues/new?body=module:%20medical_prescription_state%0Aversion:%209.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
+
+
+Credits
+=======
+
+Contributors
+------------
+
+* Dave Lasley <dave@laslabs.com>
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit http://odoo-community.org.

--- a/medical_base_kanban/__init__.py
+++ b/medical_base_kanban/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# Copyright 2016 LasLabs Inc.
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from . import models

--- a/medical_base_kanban/__openerp__.py
+++ b/medical_base_kanban/__openerp__.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+# Copyright 2016 LasLabs Inc.
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+{
+    'name': 'Medical Base - KanBan',
+    'version': '9.0.1.0.0',
+    'author': "LasLabs, Odoo Community Association (OCA)",
+    'category': 'Medical',
+    'depends': [
+        'web_kanban',
+        'medical',
+    ],
+    'website': 'https://laslabs.com',
+    'license': 'AGPL-3',
+    'data': [
+        'views/medical_base_kanban.xml',
+        'views/medical_base_stage.xml',
+        'views/medical_menu.xml',
+        'security/ir.model.access.csv',
+    ],
+    'installable': True,
+}

--- a/medical_base_kanban/models/__init__.py
+++ b/medical_base_kanban/models/__init__.py
@@ -1,0 +1,8 @@
+# -*- coding: utf-8 -*-
+# Copyright 2016 LasLabs Inc.
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from . import medical_base_kanban
+from . import medical_base_stage
+from . import medical_base_kanban_assign
+from . import medical_base_kanban_test

--- a/medical_base_kanban/models/medical_base_kanban.py
+++ b/medical_base_kanban/models/medical_base_kanban.py
@@ -1,0 +1,146 @@
+# -*- coding: utf-8 -*-
+# Copyright 2016 LasLabs Inc.
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from openerp import fields, models, api
+
+
+class MedicalBaseKanban(models.AbstractModel):
+    """ It provides abstract KanBan state mechanism for poly inherits.
+
+    All public properties are preceded with kanban_ in order to isolate
+    from child models.
+
+    There is one exception to the kanban_ prefix rule - ``stage_id``.
+    This is a required field in the KanBan widget and must be defined as such.
+    """
+
+    _name = 'medical.base.kanban'
+    _desciption = 'Medical Base KanBan'
+    _order = 'kanban_priority desc, kanban_sequence, kanban_date_assign'
+
+    kanban_sequence = fields.Integer(
+        default=10,
+        index=True,
+        help="Sequence order when displaying a list of Rxs",
+    )
+    kanban_priority = fields.Selection([
+        ('0', 'Normal'),
+        ('5', 'Medium'),
+        ('10', 'High'),
+    ],
+        index=True,
+        default='0',
+        help="Priority of the order",
+    )
+    stage_id = fields.Many2one(
+        string='State',
+        comodel_name='medical.base.stage',
+        track_visibility='onchange',
+        index=True,
+        copy=False,
+        help="The state in Kanban view",
+        # default="_default_stage_id",
+        domain=lambda s: [('res_model', '=', s._name)],
+    )
+    kanban_user_id = fields.Many2one(
+        string='Assigned To',
+        comodel_name='res.users',
+        index=True,
+        track_visibility='onchange',
+        help="The record is assigned to",
+    )
+    kanban_assign_history_ids = fields.One2many(
+        string='Assign History',
+        comodel_name='medical.base.kanban.assign',
+        inverse_name='kanban_id',
+        ondelete='cascade',
+    )
+    kanban_date_assign = fields.Datetime(
+        string='Assigned Date',
+        compute='_compute_kanban_date_assign',
+        store=True,
+        help="Date and time when record is assigned",
+    )
+    kanban_color = fields.Integer(
+        'Color Index',
+        help="Color of the Kanban card",
+    )
+    kanban_legend_blocked = fields.Char(
+        string='Kanban Blocked Explanation',
+        related='stage_id.legend_blocked',
+        help="Kanban blocked explanation",
+    )
+    kanban_legend_done = fields.Char(
+        string='Kanban Done Explanation',
+        related='stage_id.legend_done',
+        help="Kanban done explanation",
+    )
+    kanban_legend_normal = fields.Char(
+        string='Kanban Ongoing Explanation',
+        related='stage_id.legend_normal',
+        help="Kanban ongoing explanation",
+    )
+    kanban_state = fields.Selection([
+        ('normal', 'Normal Handling'),
+        ('done', 'Ready'),
+        ('blocked', 'Special Handling'),
+    ],
+        'Kanban State',
+        default='normal',
+        track_visibility='onchange',
+        required=True,
+        copy=False,
+        help="A Record's Kanban state indicates special situations affecting"
+        " it:\n"
+        "* `Normal Handling` is the default situation, and indicates no"
+        " special handling."
+        "* `Special Handling` indicates that this Record must be processed"
+        " in a special way, or by a particular agent. \n"
+        "* `Ready` indicates the Record is ready to be pulled to the next"
+        " stage.",
+    )
+    kanban_canonical_state = fields.Selection(
+        related='stage_id.state',
+    )
+
+    _group_by_full = {
+        'stage_id': lambda s, *a, **k: s._read_group_stage_ids(*a, **k),
+    }
+
+    @api.model
+    def _default_stage_id(self, model_name):
+        return
+
+    @api.multi
+    def _read_group_stage_ids(
+        self, domain, read_group_order=None, access_rights_uid=None,
+    ):
+        stage_obj = self.env['medical.base.stage'].sudo(access_rights_uid)
+        domain = [('res_model', '=', self._name)]
+        stages = stage_obj.search(domain)
+        result = [(r.id, r.display_name) for r in stages]
+        fold = {r.id: r.fold for r in stages}
+        return result, fold
+
+    @api.multi
+    @api.depends('kanban_user_id', 'stage_id')
+    def _compute_kanban_date_assign(self):
+        """ It sets new assign date and adds into assignment history """
+        for rec_id in self:
+            if not rec_id.kanban_user_id or not rec_id.stage_id:
+                return
+            history_ids = rec_id.kanban_assign_history_ids
+            if (
+                not history_ids or
+                rec_id.kanban_user_id != history_ids[0].user_id
+            ):
+                date = fields.Datetime.now()
+                rec_id.kanban_date_assign = date
+                rec_id.kanban_assign_history_ids = [
+                    (0, 0, {
+                        'user_id': rec_id.kanban_user_id.id,
+                        'stage_id': rec_id.stage_id.id,
+                        'date_assign': date,
+                    }),
+                ]

--- a/medical_base_kanban/models/medical_base_kanban_assign.py
+++ b/medical_base_kanban/models/medical_base_kanban_assign.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+# Copyright 2016 LasLabs Inc.
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from openerp import fields, models
+
+
+class MedicalBaseKanbanAssign(models.Model):
+    """ It provides KanBan assignment history for Medical """
+
+    _name = 'medical.base.kanban.assign'
+    _description = 'Medical Base State Assignments'
+    _order = 'date_assign desc'
+
+    stage_id = fields.Many2one(
+        string='State',
+        comodel_name='medical.base.stage',
+        required=True,
+    )
+    user_id = fields.Many2one(
+        string='Assigned User',
+        comodel_name='res.users',
+        required=True,
+    )
+    date_assign = fields.Datetime(
+        string='Assigned Date',
+        required=True,
+    )
+    kanban_id = fields.Many2one(
+        string='Related Record',
+        comodel_name='medical.base.kanban',
+        required=True,
+        index=True,
+    )

--- a/medical_base_kanban/models/medical_base_kanban_test.py
+++ b/medical_base_kanban/models/medical_base_kanban_test.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+# Copyright 2016 LasLabs Inc.
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from openerp import models
+
+
+class MedicalBaseKanbanTest(models.Model):
+    """ It provides a model for testing. Need to figure out a way to only
+    load while testing, instead of all the time
+    """
+    _name = 'medical.base.kanban.test'
+    _inherit = 'medical.base.kanban'

--- a/medical_base_kanban/models/medical_base_stage.py
+++ b/medical_base_kanban/models/medical_base_stage.py
@@ -1,0 +1,100 @@
+# -*- coding: utf-8 -*-
+# Copyright 2016 LasLabs Inc.
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from openerp import fields, models, api
+
+
+class MedicalBaseStage(models.Model):
+    """ It provides base stages for Medical KanBan resources.
+
+    This class provides Kanban stage attributes for use in Medical modules.
+    For the most part, it should operate similar to that of the Project
+    Kanban.
+    """
+
+    _name = 'medical.base.stage'
+    _description = 'Medical Base Stages'
+    _order = 'res_model, sequence'
+
+    name = fields.Char(
+        'State name',
+        translate=True,
+        required=True,
+        help='Displayed as the header for this state in Kanban views.',
+    )
+    description = fields.Text(
+        'Description',
+        translate=True,
+        help='Short description of state\'s meaning/purpose.',
+    )
+    sequence = fields.Integer(
+        'Sequence',
+        default=1,
+        required=True,
+        index=True,
+        help='Order of state in relation to others.',
+    )
+    legend_priority = fields.Char(
+        'Priority Management Explanation',
+        translate=True,
+        default='Star an item when it needs to be escalated ahead of other'
+        '  items due to special circumstances.',
+        help='Explanation text to help users using the star and priority'
+        ' mechanism on stages or RXs that are in this stage.',
+    )
+    legend_blocked = fields.Char(
+        'Kanban Blocked Explanation',
+        translate=True,
+        default='Block an item if it requires handling by a specialist, such'
+        ' as a pharmacist.',
+        help='Override the default value displayed for the blocked state for'
+        ' kanban selection, when the RX is in that stage.',
+    )
+    legend_done = fields.Char(
+        'Kanban Valid Explanation',
+        translate=True,
+        default='Item has been fully processed in this stage.',
+        help='Override the default value displayed for the done state for'
+        ' kanban selection, when the RX is in that stage.',
+    )
+    legend_normal = fields.Char(
+        'Kanban Ongoing Explanation',
+        translate=True,
+        default='This is the default situation, and indicates that a record'
+        ' can be processed by any user working this queue.',
+        help='Override the default value displayed for the normal state for'
+        ' kanban selection, when the RX is in that stage.',
+    )
+    fold = fields.Boolean(
+        'Folded in RX Pipeline',
+        help='This stage is folded in the kanban view when'
+        ' there are no records in that stage to display.',
+    )
+    color = fields.Integer(
+        'Color Index',
+        default=1,
+        help='Color index to be used if the Rx does not have one defined',
+    )
+    res_model = fields.Char(
+        required=True,
+        index=True,
+        default=lambda s: s._default_res_model(),
+    )
+    state = fields.Selection(
+        lambda s: s._get_state_select(),
+    )
+
+    @api.model
+    def _default_res_model(self):
+        return self.env.context['params'].get('model', '')
+
+    @api.model
+    def _get_state_select(self):
+        return [
+            ('draft', 'New'),
+            ('open', 'In Progress'),
+            ('pending', 'Pending'),
+            ('done', 'Done'),
+            ('cancelled', 'Cancelled'),
+        ]

--- a/medical_base_kanban/security/ir.model.access.csv
+++ b/medical_base_kanban/security/ir.model.access.csv
@@ -1,0 +1,7 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_medical_base_stage_user,access.medical.base.stage.user,model_medical_base_stage,medical.group_medical_user,1,0,0,0
+access_medical_base_stage_configurator,access.medical.base.stage.configurator,model_medical_base_stage,medical.group_medical_configurator,1,1,1,1
+access_medical_base_kanban_user,access.medical.base.kanban.user,model_medical_base_kanban,medical.group_medical_user,1,0,0,0
+access_medical_base_kanban_configurator,access.medical.base.kanban.configurator,model_medical_base_kanban,medical.group_medical_configurator,1,1,1,1
+access_medical_base_kanban_assign_user,access.medical.base.kanban.assign.user,model_medical_base_kanban_assign,medical.group_medical_user,1,0,0,0
+access_medical_base_kanban_assign_configurator,access.medical.base.kanban.assign.configurator,model_medical_base_kanban_assign,medical.group_medical_configurator,1,1,1,1

--- a/medical_base_kanban/tests/__init__.py
+++ b/medical_base_kanban/tests/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# Copyright 2016 LasLabs Inc.
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from . import test_medical_base_kanban

--- a/medical_base_kanban/tests/test_medical_base_kanban.py
+++ b/medical_base_kanban/tests/test_medical_base_kanban.py
@@ -1,0 +1,91 @@
+# -*- coding: utf-8 -*-
+# Copyright 2016 LasLabs Inc.
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+import mock
+
+from contextlib import contextmanager
+
+from openerp.tests.common import TransactionCase
+
+
+model = 'openerp.addons.medical_base_kanban.models.medical_base_kanban'
+
+
+class TestMedicalBaseKanban(TransactionCase):
+
+    def setUp(self):
+        super(TestMedicalBaseKanban, self).setUp()
+        self.model = self.env['medical.base.kanban.test']
+        self.stage_id = self.env['medical.base.stage'].create({
+            'name': 'stage',
+            'res_model': self.model._name,
+        })
+        self.record_id = self.model.create({
+            'stage_id': self.stage_id.id,
+        })
+        self.datetime = '2016-01-01 01:23:45'
+
+    @contextmanager
+    def mock_fields(self):
+        """ It mocks fields import from model & overrides Datetime.now """
+        with mock.patch('%s.fields' % model) as fields:
+            fields.Datetime.now.return_value = self.datetime
+            yield fields
+
+    def reassign_record(self, user_id):
+        self.record_id.write({
+            'kanban_user_id': user_id.id
+        })
+
+    def test_compute_kanban_date_assign_initial_date(self):
+        """ It should set date_assign on initial assignment """
+        with self.mock_fields():
+            self.reassign_record(self.env.ref('base.user_root'))
+            self.assertEqual(
+                self.datetime, self.record_id.kanban_date_assign,
+            )
+
+    def test_compute_kanban_date_assign_initial_history(self):
+        """ It should set history on initial assignment """
+        with self.mock_fields():
+            self.reassign_record(self.env.ref('base.user_root'))
+            self.assertEqual(
+                self.env.ref('base.user_root'),
+                self.record_id.kanban_assign_history_ids[0].user_id,
+            )
+
+    def test_compute_kanban_date_reassign_same_history(self):
+        """ It should not set additional history on reassign to same user """
+        with self.mock_fields():
+            self.reassign_record(self.env.ref('base.user_root'))
+            self.reassign_record(self.env.ref('base.user_root'))
+            self.assertEqual(1, len(self.record_id.kanban_assign_history_ids))
+
+    def test_compute_kanban_date_reassign_same_user(self):
+        """ It should not set assign date on reassign to same user """
+        with self.mock_fields() as fields:
+            self.reassign_record(self.env.ref('base.user_root'))
+            expect = '2016-02-01 00:00:00'
+            fields.Datetime.now.return_value = expect
+            self.reassign_record(self.env.ref('base.user_root'))
+            self.assertNotEqual(expect, self.record_id.kanban_date_assign)
+
+    def test_compute_kanban_date_reassign_history(self):
+        """ It should set additional history on reassign to new user """
+        with self.mock_fields():
+            self.reassign_record(self.env.ref('base.user_root'))
+            self.reassign_record(self.env.ref('base.user_demo'))
+            self.assertEqual(
+                self.env.ref('base.user_demo'),
+                self.record_id.kanban_assign_history_ids[0].user_id,
+            )
+
+    def test_compute_kanban_date_reassign_new_user(self):
+        """ It should set assign date on reassign to new user """
+        with self.mock_fields() as fields:
+            self.reassign_record(self.env.ref('base.user_root'))
+            expect = '2016-02-01 00:00:00'
+            fields.Datetime.now.return_value = expect
+            self.reassign_record(self.env.ref('base.user_demo'))
+            self.assertEqual(expect, self.record_id.kanban_date_assign)

--- a/medical_base_kanban/views/medical_base_kanban.xml
+++ b/medical_base_kanban/views/medical_base_kanban.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!--
+    Copyright 2016 LasLabs Inc.
+    License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+-->
+
+<odoo>
+    
+    <record id="medical_base_kanban_view" model="ir.ui.view">
+        <field name="name">Medical KanBan</field>
+        <field name="model">medical.base.kanban</field>
+        <field name="arch" type="xml">
+            <kanban default_group_by="stage_id" class="o_kanban_small_column">
+                <field name="display_name" />
+                <field name="kanban_color" />
+                <field name="kanban_priority" />
+                <field name="stage_id"
+                       options='{"group_by_tooltip": {"description": "Stage Description",
+                                                      "legend_priority": "Use of stars",
+                                                      },
+                                }'
+                       />
+                <field name="kanban_sequence" />
+                <field name="kanban_legend_blocked" />
+                <field name="kanban_legend_normal" />
+                <field name="kanban_legend_done" />
+                <field name="kanban_user_id" />
+                <templates>
+                    <t t-name="kanban-box">
+                        <div t-attf-class="oe_kanban_color_#{kanban_getcolor(record.kanban_color.raw_value)} o_kanban_record oe_kanban_global_click">
+
+                            <div class="o_dropdown_kanban dropdown" groups="base.group_user">
+
+                                <a class="dropdown-toggle btn"
+                                   data-toggle="dropdown"
+                                   href="#"
+                                   >
+                                    <span class="fa fa-bars fa-lg" />
+                                </a>
+                                <ul class="dropdown-menu"
+                                    role="menu"
+                                    aria-labelledby="dLabel"
+                                    >
+                                    <li t-if="widget.editable">
+                                        <a type="edit">Edit</a>
+                                    </li>
+                                    <li t-if="widget.deletable">
+                                        <a type="delete">Delete</a>
+                                    </li>
+                                    <li>
+                                        <ul class="oe_kanban_colorpicker"
+                                            data-field="kanban_color"
+                                            />
+                                    </li>
+                                </ul>
+                                
+                            </div>
+                            
+                            <div class="o_kanban_title">
+                                <div groups="base.group_user">
+                                    <field name="kanban_state" widget="kanban_state_selection"/>
+                                </div>
+                                <field name="display_name" />
+                            </div>
+                            
+                            <div class="oe_kanban_details">
+                                <!-- Child modules should add data here -->
+                            </div>
+                            
+                            <div class="o_kanban_footer">
+                                <div class="oe_kanban_bottom_left">
+                                    <field name="kanban_priority" widget="priority" />
+                                </div>
+                                <div class="oe_kanban_bottom_right" t-if="record.kanban_user_id">
+                                    <img t-att-src="kanban_image('res.users', 'image_small', record.kanban_user_id.raw_value)"
+                                         t-att-title="record.kanban_user_id.value"
+                                         class="oe_kanban_avatar_smallbox pull-right"
+                                         />
+                                </div>
+                            </div>
+                        </div>
+                        
+                    </t>
+                </templates>
+            </kanban>
+        </field>
+    </record>
+    
+</odoo>

--- a/medical_base_kanban/views/medical_base_stage.xml
+++ b/medical_base_kanban/views/medical_base_stage.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!--
+    Copyright 2016 LasLabs Inc.
+    License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+-->
+
+<odoo>
+        
+    <record id="medical_base_stage_view_form" model="ir.ui.view">
+        <field name="name">medical.base.stage.view.form</field>
+        <field name="model">medical.base.stage</field>
+        <field name="arch" type="xml">
+            <form string="Medical Stage">
+                <header />
+                <sheet>
+                    <group name="data">
+                        <group name="stage_info">
+                            <field name="name" />
+                            <field name="res_model" />
+                            <field name="sequence" />
+                            <field name="fold" />
+                            <field name="color" />
+                            <field name="description" />
+                        </group>
+                        <group name="kanban_info">
+                            <field name="legend_priority" />
+                            <field name="legend_blocked" />
+                            <field name="legend_done" />
+                            <field name="legend_normal" />
+                        </group>
+                    </group>
+                </sheet>
+            </form>
+        </field>
+    </record>
+    
+    <record id="medical_base_stage_view_tree" model="ir.ui.view">
+        <field name="name">medical.base.stage.view.tree</field>
+        <field name="model">medical.base.stage</field>
+        <field name="arch" type="xml">
+            <tree string="Rx States">
+                <field name="name" />
+                <field name="sequence" />
+                <field name="color" />
+                <field name="legend_priority" />
+            </tree>
+        </field>
+    </record>
+    
+    <record model="ir.actions.act_window" id="medical_base_stage_action">
+         <field name="name">Medical Stages</field>
+         <field name="res_model">medical.base.stage</field>
+         <field name="type">ir.actions.act_window</field>
+         <field name="view_type">form</field>
+         <field name="view_mode">tree,form</field>
+     </record>
+        
+</odoo>

--- a/medical_base_kanban/views/medical_menu.xml
+++ b/medical_base_kanban/views/medical_menu.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+    Copyright 2016 LasLabs Inc.
+    License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+-->
+
+<odoo>
+
+    <menuitem id="medical_root_kanban"
+              name="KanBan"
+              parent="medical.medical_root_sub"
+              sequence="190" />
+
+    <menuitem id="medical_base_stage_menu"
+              name="Stages"
+              parent="medical_root_kanban"
+              sequence="50"
+              action="medical_base_stage_action" />
+
+</odoo>


### PR DESCRIPTION
- Create a model to handle abstract stages with Kanban
# 
# Medical Base -  Kanban

This module provides abstract KanBan logic for use in Medical Resources.
# Usage

The `medical.base.kanban` model should be inherited in order to add KanBan
and Stage functionality to any record

```
class MyModel(models.Model):
    _name = 'my.model'
    _inherit = 'medical.base.kanban'
```

A Base KanBan view is also provided, which can be integrated into child views

```
<record id="my_model_kanban_view" model="ir.ui.view">
    <field name="name">My Record</field>
    <field name="model">my.model</field>
    <field name="inherit_id" ref="medical_base_state.medical_base_kanban_view" />
    <field name="arch" type="xml">
        <!-- Add your contextual changes here w/ XPath -->
    </field>
</record>
```
