### PR TITLE
[FIX][8.0] medical_insurance: Add on change pass-thrus

### DIFF
--- a/medical_insurance/models/medical_insurance_company.py
+++ b/medical_insurance/models/medical_insurance_company.py
@@ -38,3 +38,11 @@ class MedicalInsuranceCompany(models.Model):
     def create(self, vals):
         vals['is_insurance_company'] = True
         return super(MedicalInsuranceCompany, self).create(vals)
+
+    @api.multi
+    def onchange_state(self, state_id):
+        return self.partner_id.onchange_state(state_id)
+
+    @api.multi
+    def onchange_address(self, use_parent_address, parent_id):
+        return self.partner_id.onchange_address(use_parent_address, parent_id)

--- a/medical_insurance/tests/__init__.py
+++ b/medical_insurance/tests/__init__.py
@@ -1,22 +1,4 @@
 # -*- coding: utf-8 -*-
-##############################################################################
-#
-#    Author: Dave Lasley <dave@laslabs.com>
-#    Copyright: 2015 LasLabs, Inc [https://laslabs.com]
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as
-#    published by the Free Software Foundation, either version 3 of the
-#    License, or (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU Affero General Public License for more details.
-#
-#    You should have received a copy of the GNU Affero General Public License
-#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
-##############################################################################
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from . import models
+from . import test_medical_insurance_company

--- a/medical_insurance/tests/test_medical_insurance_company.py
+++ b/medical_insurance/tests/test_medical_insurance_company.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+# Copyright 2016 LasLabs Inc.
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+import mock
+from openerp.tests.common import TransactionCase
+from openerp.addons.base.res.res_partner import res_partner
+
+
+class TestMedicalInsuranceCompany(TransactionCase):
+
+    def setUp(self,):
+        super(TestMedicalInsuranceCompany, self).setUp()
+        self.model_obj = self.env['medical.insurance.company']
+        self.vals = {
+            'name': 'Test Insurance Co',
+        }
+
+    def _new_record(self, ):
+        return self.model_obj.create(self.vals)
+
+    def test_is_insurance_company(self, ):
+        ''' Validate is_insurance_company is set on partner '''
+        rec_id = self._new_record()
+        self.assertTrue(rec_id.is_insurance_company)
+
+    def test_onchange_state_passthru(self, ):
+        ''' Validate that onchange_state is passed thru to partner '''
+        rec_id = self._new_record()
+        with mock.patch.object(res_partner, 'onchange_state') as mk:
+            expect = 'Expect'
+            rec_id.onchange_state(expect)
+            mk.assert_called_once_with(expect)
+
+    def test_onchange_address_passthru(self, ):
+        ''' Validate that onchange_address is passed thru to partner '''
+        rec_id = self._new_record()
+        with mock.patch.object(res_partner, 'onchange_address') as mk:
+            expect = 'Expect', 'Expect2'
+            rec_id.onchange_address(*expect)
+            mk.assert_called_once_with(*expect)


### PR DESCRIPTION
* Add on change pass-thru for `state` & `address` to `res.partner` on `medical.insurance.company` - fixes #128