### PR TITLE
[9.0][FIX] medical_lab: Add missing dependency

### DIFF
--- a/medical_lab/__openerp__.py
+++ b/medical_lab/__openerp__.py
@@ -13,6 +13,7 @@
     "installable": True,
     "depends": [
         "medical_pathology",
+        "medical_physician",
     ],
     "data": [
         "views/medical_lab.xml",


### PR DESCRIPTION
* Add missing `medical_physician` dependency to `medical_lab`

The module load order in v9 masked the issue, but it was noticed in our v10 incubator - https://github.com/LasLabs/vertical-medical/pull/114#issuecomment-273924056

cc @laslabs