### PR TITLE
[9.0][FIX] Convert all product_uom grams to units.

### DIFF
--- a/medical_medicament/demo/medical_medicament_demo.xml
+++ b/medical_medicament/demo/medical_medicament_demo.xml
@@ -6,8 +6,8 @@
 
     <record id="product_product_advil_1" model="product.product">
         <field name="name">Advil</field>
-        <field name="uom_id" ref="product.product_uom_gram" />
-        <field name="uom_po_id" ref="product.product_uom_gram" />
+        <field name="uom_id" ref="product.product_uom_unit" />
+        <field name="uom_po_id" ref="product.product_uom_unit" />
         <field name="weight">22.6796</field>
         <field name="volume">0.008</field>
         <field name="categ_id" ref="product.product_category_5" />
@@ -33,8 +33,8 @@
 
     <record id="product_product_advil_2" model="product.product">
         <field name="name">Advil Extra Strength</field>
-        <field name="uom_id" ref="product.product_uom_gram" />
-        <field name="uom_po_id" ref="product.product_uom_gram" />
+        <field name="uom_id" ref="product.product_uom_unit" />
+        <field name="uom_po_id" ref="product.product_uom_unit" />
         <field name="weight">15</field>
         <field name="volume">0.0033</field>
         <field name="categ_id" ref="product.product_category_5" />

--- a/medical_medication/demo/medical_medicament_demo.xml
+++ b/medical_medication/demo/medical_medicament_demo.xml
@@ -6,8 +6,8 @@
 
     <record id="product_product_truvada_1" model="product.product">
         <field name="name">Truvada</field>
-        <field name="uom_id" ref="product.product_uom_gram" />
-        <field name="uom_po_id" ref="product.product_uom_gram" />
+        <field name="uom_id" ref="product.product_uom_unit" />
+        <field name="uom_po_id" ref="product.product_uom_unit" />
         <field name="weight">15</field>
         <field name="categ_id" ref="product.product_category_5" />
         <field name="type">consu</field>
@@ -31,8 +31,8 @@
 
     <record id="product_product_aralen_1" model="product.product">
         <field name="name">Aralen</field>
-        <field name="uom_id" ref="product.product_uom_gram" />
-        <field name="uom_po_id" ref="product.product_uom_gram" />
+        <field name="uom_id" ref="product.product_uom_unit" />
+        <field name="uom_po_id" ref="product.product_uom_unit" />
         <field name="weight">17</field>
         <field name="categ_id" ref="product.product_category_5" />
         <field name="type">consu</field>

--- a/sale_medical_prescription/demo/sale_order_line_demo.xml
+++ b/sale_medical_prescription/demo/sale_order_line_demo.xml
@@ -7,7 +7,7 @@
     <record id="sale_order_medical_order_line_1" model="sale.order.line">
         <field name="prescription_order_line_id" ref="medical_prescription.medical_prescription_order_order_line_1" />
         <field name="order_id" ref="sale_medical_prescription.sale_order_medical_order_1" />
-        <field name="product_uom" ref="product.product_uom_gram" />
+        <field name="product_uom" ref="product.product_uom_unit" />
         <field name="name">[ADV] Advil</field>
         <field name="product_id" ref="medical_medicament.product_product_advil_1" />
         <field name="product_uom_qty">4</field>
@@ -17,7 +17,7 @@
     <record id="sale_order_medical_order_line_2" model="sale.order.line">
         <field name="prescription_order_line_id" ref="medical_prescription.medical_prescription_order_order_line_2" />
         <field name="order_id" ref="sale_medical_prescription.sale_order_medical_order_1" />
-        <field name="product_uom" ref="product.product_uom_gram" />
+        <field name="product_uom" ref="product.product_uom_unit" />
         <field name="name">[ADV-XSTNGTH] Advil Extra Strength</field>
         <field name="product_id" ref="medical_medicament.product_product_advil_2" />
         <field name="product_uom_qty">100</field>
@@ -27,7 +27,7 @@
     <record id="sale_order_medical_order_line_3" model="sale.order.line">
         <field name="prescription_order_line_id" ref="medical_prescription.medical_prescription_order_order_line_3" />
         <field name="order_id" ref="sale_medical_prescription.sale_order_medical_order_2" />
-        <field name="product_uom" ref="product.product_uom_gram" />
+        <field name="product_uom" ref="product.product_uom_unit" />
         <field name="name">[ADV] Advil</field>
         <field name="product_id" ref="medical_medicament.product_product_advil_1" />
         <field name="product_uom_qty">10</field>
@@ -37,7 +37,7 @@
     <record id="sale_order_medical_order_line_4" model="sale.order.line">
         <field name="prescription_order_line_id" ref="medical_prescription.medical_prescription_order_order_line_4" />
         <field name="order_id" ref="sale_medical_prescription.sale_order_medical_order_3" />
-        <field name="product_uom" ref="product.product_uom_gram" />
+        <field name="product_uom" ref="product.product_uom_unit" />
         <field name="name">[ADV] Advil</field>
         <field name="product_id" ref="medical_medicament.product_product_advil_1" />
         <field name="product_uom_qty">180</field>
@@ -47,7 +47,7 @@
     <record id="sale_order_medical_order_line_5" model="sale.order.line">
         <field name="prescription_order_line_id" ref="medical_prescription.medical_prescription_order_order_line_5" />
         <field name="order_id" ref="sale_medical_prescription.sale_order_medical_order_4" />
-        <field name="product_uom" ref="product.product_uom_gram" />
+        <field name="product_uom" ref="product.product_uom_unit" />
         <field name="name">[TRUV] Truvada</field>
         <field name="product_id" ref="medical_medication.product_product_truvada_1" />
         <field name="product_uom_qty">300</field>
@@ -57,7 +57,7 @@
     <record id="sale_order_medical_order_line_6" model="sale.order.line">
         <field name="prescription_order_line_id" ref="medical_prescription.medical_prescription_order_order_line_6" />
         <field name="order_id" ref="sale_medical_prescription.sale_order_medical_order_5" />
-        <field name="product_uom" ref="product.product_uom_gram" />
+        <field name="product_uom" ref="product.product_uom_unit" />
         <field name="name">[ARLN] Aralen</field>
         <field name="product_id" ref="medical_medication.product_product_aralen_1" />
         <field name="product_uom_qty">250</field>


### PR DESCRIPTION
These changes were done on 10.0, however are needed for sale_stock_medical_prescription. Causing issues since the default uom is units, not grams.