### PR TITLE
[10.0][ADD] medical: Add _get_medical_entity method

### DIFF
--- a/medical/models/res_partner.py
+++ b/medical/models/res_partner.py
@@ -44,6 +44,14 @@ class ResPartner(models.Model):
     )
 
     @api.multi
+    def _get_medical_entity(self):
+        self.ensure_one()
+        if self.type and self.type[:7] == 'medical':
+            return self.env[self.type].search([
+                ('partner_id', '=', self.id),
+            ])
+
+    @api.multi
     def _compute_patient_ids_and_count(self):
         for record in self:
             patients = self.env['medical.patient'].search([

--- a/medical/tests/__init__.py
+++ b/medical/tests/__init__.py
@@ -1,2 +1,6 @@
 # -*- coding: utf-8 -*-
+# Copyright 2016-2017 LasLabs Inc.
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
+
+from . import test_res_partner
 from . import test_medical_patient

--- a/medical/tests/test_res_partner.py
+++ b/medical/tests/test_res_partner.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+# Copyright 2016-2017 LasLabs Inc.
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
+
+from odoo.tests.common import TransactionCase
+
+
+class TestResPartner(TransactionCase):
+
+    def setUp(self):
+        super(TestResPartner, self).setUp()
+        self.partner_1 = self.env.ref(
+            'medical.res_partner_patient_1'
+        )
+        self.patient_1 = self.env.ref(
+            'medical.medical_patient_patient_1'
+        )
+
+    def test_get_medical_entity(self):
+        """ Test returns correct medical entity """
+        self.partner_1.type = 'medical.patient'
+        res = self.partner_1._get_medical_entity()
+        self.assertEquals(
+            res.partner_id,
+            self.partner_1,
+        )
+
+    def test_get_medical_entity_no_type(self):
+        """ Test returns nothing if no type """
+        self.partner_1.type = None
+        self.assertFalse(
+            self.partner_1._get_medical_entity(),
+        )
+
+    def test_get_medical_entity_not_medical(self):
+        """ Test returns nothing if not medical type """
+        self.partner_1.type = 'invoice'
+        self.assertFalse(
+            self.partner_1._get_medical_entity(),
+        )


### PR DESCRIPTION
This adds a simple method on the partner that will return the related medical entity. This becomes fairly useful in later modules when we could be dealing in abstract contexts.