### PR TITLE
[10.0][FIX] medical: Copyright audit

### DIFF
--- a/medical/README.rst
+++ b/medical/README.rst
@@ -103,9 +103,7 @@ Contributors
 * Dave Lasley <dave@laslabs.com>
 * Jonathan Nemry <jonathan.nemry@acsone.eu>
 * Brett Wood <bwood@laslabs.com>
-* Ruchir Shukla <ruchir@techreceptives.com>
-* Parthiv Patel <parthiv@techreceptives.com>
-* Nhomar Hernandéz <nhomar@vauxoo.com>
+* Jordi Ballester Alomar <jordi.ballester@eficent.com>
 
 Maintainer
 ----------

--- a/medical/models/medical_patient.py
+++ b/medical/models/medical_patient.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-# Copyright 2004 Tech-Receptives
 # Copyright 2016 LasLabs Inc.
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
 
@@ -12,9 +11,7 @@ from odoo.exceptions import ValidationError, UserError
 
 
 class MedicalPatient(models.Model):
-    """
-    The concept of Patient included in medical.
-    """
+
     _name = 'medical.patient'
     _description = 'Medical Patient'
     _inherit = 'medical.abstract.entity'

--- a/medical/models/res_partner.py
+++ b/medical/models/res_partner.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-# Copyright 2004 Tech-Receptives
 # Copyright 2016 LasLabs Inc.
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
 

--- a/medical/tests/__init__.py
+++ b/medical/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2016-2017 LasLabs Inc.
+# Copyright 2016 LasLabs Inc.
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
 
 from . import test_res_partner

--- a/medical/tests/test_res_partner.py
+++ b/medical/tests/test_res_partner.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2016-2017 LasLabs Inc.
+# Copyright 2016 LasLabs Inc.
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
 
 from odoo.tests.common import TransactionCase

--- a/medical/views/medical_abstract_entity.xml
+++ b/medical/views/medical_abstract_entity.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Copyright 2016-2017 LasLabs Inc.
+<!-- Copyright 2016 LasLabs Inc.
      License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl). -->
 
 <odoo>

--- a/medical/views/medical_menu.xml
+++ b/medical/views/medical_menu.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Copyright 2016-2017 LasLabs Inc.
+<!-- Copyright 2016 LasLabs Inc.
      License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl). -->
 
 <odoo>


### PR DESCRIPTION
* Audit line-by-line attribution + code content against original OeMedical project to determine correct attributions

I audited `medical` - the only code left from original are random whitespace and closing tags. I believe that this is enough to call it a completely unique product. Short of completely recreating this repo, I don't think that we can even do anything about this - it's just the way git works.

Additionally, I removed Tech Receptives from a few file copyrights after investigation. At this point my team has rewritten more than 75% of each of these files, so I would say that we are the true claim there. As mentioned, Parthiv is still in a few of the line-by-line attributions, but it's whitespace and closing tags.

* [Original](https://bazaar.launchpad.net/~oemedical-commiter/oemedical/trunk/files/head:/oemedical/)

@jbeficent - You were in the line by line attribution, but not in the readme so I added you. 

As a note - I feel bad removing attribution, but I never want to have to audit like this again & leaving this old attribution needlessly I believe leaves us open to it simply because of the reputation.

Re #183

Once approved and merged, this will be backported to 9