### PR TITLE
[FIX] Activity definition's values of Medication Request

### DIFF
--- a/medical_medication_request/models/__init__.py
+++ b/medical_medication_request/models/__init__.py
@@ -6,3 +6,4 @@ from . import medical_request
 from . import medical_medication_administration
 from . import medical_medication_request
 from . import stock_move_line
+from . import workflow_activity_definition

--- a/medical_medication_request/models/workflow_activity_definition.py
+++ b/medical_medication_request/models/workflow_activity_definition.py
@@ -1,0 +1,22 @@
+# Copyright 2017 Creu Blanca
+# Copyright 2017 Eficent Business and IT Consulting Services, S.L.
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
+
+from odoo import models
+
+
+class ActivityDefinition(models.Model):
+    # FHIR entity: Activity Definition
+    # (https://www.hl7.org/fhir/activitydefinition.html)
+    _inherit = 'workflow.activity.definition'
+
+    def _get_medical_values(self, vals, parent=False, plan=False, action=False
+                            ):
+        values = super(ActivityDefinition, self)._get_medical_values(
+            vals, parent=False, plan=False, action=False)
+        if self.model_id.model == 'medical.medication.request':
+            values.update({
+                'product_id': self.service_id.id,
+                'product_uom_id': self.service_id.uom_id.id,
+            })
+        return values


### PR DESCRIPTION
The definition of a medication requests differs a bit from the other requests.
That's why when executing a plan definition on a Care Plan, the provided values in order to generate medication requests should be properly updated.

@jbeficent @etobella 