### PR TITLE
[10.0][REM] medical: Broken search filter

### DIFF
--- a/medical/__manifest__.py
+++ b/medical/__manifest__.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
-# Copyright 2016 LasLabs Inc.
+# Copyright 2016-2018 LasLabs Inc.
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
 
 {
     'name': 'Odoo Medical',
-    'version': '10.0.1.1.0',
+    'version': '10.0.1.1.1',
     'category': 'Medical',
     'depends': [
         'product',

--- a/medical/views/medical_abstract_entity.xml
+++ b/medical/views/medical_abstract_entity.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Copyright 2016 LasLabs Inc.
+<!-- Copyright 2016-2018 LasLabs Inc.
      License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl). -->
 
 <odoo>
@@ -386,9 +386,6 @@
                 <field name="partner_id" invisible="1" />
                 <filter string="Deactivated"
                         domain="[('active', '=', 0)]" />
-                <filter string="Tag"
-                        domain="[]"
-                        context="{'group_by':'category_id'}" />
                 <filter string="Parent"
                         domain="[]"
                         context="{'group_by':'parent_id'}" />


### PR DESCRIPTION
* Remove ``medical.abstract.entity`` search filter for grouping by ``category_id``, which was not supported because the field is computed and not stored